### PR TITLE
issue #3 修正地圖探索搜尋功能 ＆ 路線規劃清空及 trip_id 唯一性

### DIFF
--- a/schedules/views.py
+++ b/schedules/views.py
@@ -138,10 +138,12 @@ def get_schedule(request):
         .values(
             "spot__latitude",
             "spot__longitude",
+            "updated_at",
             "spot__name",
             "start_time",
             "date",
+            "trip_id",
         )
-        .order_by("date", "start_time")
+        .order_by("date", "start_time", "updated_at")
     )
     return JsonResponse(list(schedule_data), safe=False)

--- a/static/scripts/route.js
+++ b/static/scripts/route.js
@@ -33,8 +33,8 @@ function initMap() {
 function getTripIdFromUrl() {
     var currentUrl = window.location.href;
     var urlParts = currentUrl.split('/');
-    var idIndex = urlParts.indexOf('trips') + 1; // 找到 "trips" 后面的部分
-    return idIndex !== -1 ? urlParts[idIndex] : null; // 获取 ID
+    var idIndex = urlParts.indexOf('trips') + 1;
+    return idIndex !== -1 ? urlParts[idIndex] : null; 
 }
 
 function loadSchedule() {

--- a/static/styles/detail.css
+++ b/static/styles/detail.css
@@ -5,7 +5,7 @@ body {
 #map-container {
     display: flex;
     position: relative;
-    height: calc(100vh - 87.99px);
+    height: 100vh;
 }
 
 #map {

--- a/templates/schedules/index.html
+++ b/templates/schedules/index.html
@@ -1,6 +1,7 @@
 {% extends 'layouts/base.html' %} 
 {% block content %}
 {% load static %}
+<link rel="stylesheet" href="{% static "styles/wait_web.css" %}">
 
 <div class="bg-blue-50" style="height:calc(100vh - 88px); overflow: hidden;">
 
@@ -22,7 +23,7 @@
         <!-- 日期頁籤 -->
         <div role="tab" class="tabs flex text-start h-14">
           {% for day in date_range %}
-            <button id="btn-{{ day|date:'Y-m-d' }}" class="tab h-14 border transition-all ease-in-out text-slate-700 hover:bg-gray-200" data-date="{{ day|date:'Y-m-d' }}" onclick="showTab('{{ day|date:'Y-m-d' }}', 'btn-{{ day|date:'Y-m-d' }}')">
+            <button id="btn-{{ day|date:'Y-m-d' }}" class="tab h-14 border transition-all ease-in-out text-slate-700 hover:bg-gray-200" data-date="{{ day|date:'Y-m-d'}}" onclick="showTab('{{ day|date:'Y-m-d' }}', 'btn-{{ day|date:'Y-m-d' }}', '{{ trip.id }}')">
               {{ day|date:"Y-m-d" }}
             </button>
           {% endfor %}

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -25,7 +25,7 @@
         </a>
       </li>
       <li>
-        <a href="#hotspots-section" class="mr-10 text-xl font-bold hover:text-light-blue">熱門景點</a>
+        <a href="#hotspots-section" class="mr-10 text-xl font-bold hover:text-light-blue">景點探索</a>
       </li>
       <li>
         <a href="{% url 'trips:index' %}" class="mr-10 text-xl font-bold hover:text-light-blue">立即規劃</a>
@@ -44,7 +44,7 @@
           style="background-image: url({% static 'img/membericon.png' %})"
           {%endif %}
         ></button>
-
+        
         <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52 absolute top-14 right-0">
           <li><a href="{% url 'logout' %}">Logout</a></li>
           <li><a>Settings</a></li>

--- a/templates/spots/add.html
+++ b/templates/spots/add.html
@@ -1,10 +1,7 @@
 {% extends "layouts/base.html" %} {% block content %}
 <div class="flex justify-center items-center">
   <div>
-    <img src="https://picsum.photos/200" alt="" />
-  </div>
-  <div>
-    <h2>要加在哪</h2>
+    <h1>要加在哪?</h1>
   </div>
 </div>
 

--- a/templates/spots/add.html
+++ b/templates/spots/add.html
@@ -1,9 +1,11 @@
 {% extends "layouts/base.html" %} {% block content %}
-<div>
-  <img src="https://picsum.photos/200" alt="" />
-</div>
-<div>
-  <h2>要加在哪？</h2>
+<div class="flex justify-center items-center">
+  <div>
+    <img src="https://picsum.photos/200" alt="" />
+  </div>
+  <div>
+    <h2>要加在哪</h2>
+  </div>
 </div>
 
 {% for item in trips_dates %}
@@ -25,4 +27,5 @@
     {% endfor %}
   </div>
 </div>
-{% endfor %}{% endblock %}
+{% endfor %}
+{% endblock %}

--- a/templates/trips/index.html
+++ b/templates/trips/index.html
@@ -1,6 +1,5 @@
 {% extends 'layouts/base.html' %} 
 {% load static %}
-
 {% block content %}
   <div class="h-screen bg-blue-50">
     <header class="flex justify-start bg-sky-800">
@@ -27,9 +26,9 @@
       } }">
         <div class="flex">
           <img src="{% if trip.t.image %}{{ trip.t.image.url }}{% else %}{% static 'img/tripdefault.png' %}{% endif %}" class="w-[266px] h-[200px]" alt="">
-          <form action="{{ trip.t.id }}/schedules/" method="post">
+          <form id="trip-form" action="{{ trip.t.id }}/schedules/" method="post">
             {% csrf_token %}
-            <button class="mx-3 my-3">
+            <button  id="trip-button" type="submit" class="mx-3 my-3">
               <div class="flex items-start font-bold text-sky-800 text-xl">{{ trip.t.name }}</div>
               <div>{{ trip.t.start_date|date:'Y-m-d' }}~{{ trip.t.end_date|date:'Y-m-d' }}</div>
             </button>
@@ -53,4 +52,5 @@
     <a class="px-2 py-2 text-white border rounded-lg bg-sky-800 hover:bg-sky-950" href="{% url 'spots:index' %}">景點清單</a>
   </div>
 </div>
+<script src="{% static "scripts/route.js" %}"></script>
 {% endblock %}

--- a/templates/trips/index.html
+++ b/templates/trips/index.html
@@ -28,7 +28,7 @@
           <img src="{% if trip.t.image %}{{ trip.t.image.url }}{% else %}{% static 'img/tripdefault.png' %}{% endif %}" class="w-[266px] h-[200px]" alt="">
           <form id="trip-form" action="{{ trip.t.id }}/schedules/" method="post">
             {% csrf_token %}
-            <button  id="trip-button" type="submit" class="mx-3 my-3">
+            <button class="mx-3 my-3">
               <div class="flex items-start font-bold text-sky-800 text-xl">{{ trip.t.name }}</div>
               <div>{{ trip.t.start_date|date:'Y-m-d' }}~{{ trip.t.end_date|date:'Y-m-d' }}</div>
             </button>

--- a/templates/trips/map.html
+++ b/templates/trips/map.html
@@ -1,6 +1,4 @@
 {% load static %}
-<!DOCTYPE html>
-<html>
 <head>
     <link rel="stylesheet" href="{% static 'styles/style.css' %}" />
     <link rel="stylesheet" href="{% static 'styles/detail.css' %}">
@@ -14,16 +12,16 @@
 
         <div id="search-container">
             <input id="pac-input" class="controls" type="text" placeholder="搜索地點"/>
-            <button class="search-button" onclick="searchNearby('restaurant')">搜索附近餐廳</button>
+            <button class="search-button" onclick="searchNearby('restaurant')">搜索附近餐廳
+            </button>
             <button class="search-button" onclick="searchNearby('tourist_attraction')">搜索附近觀光景點</button>
             <button class="search-button" onclick="searchNearby('park')">搜索附近公園</button>
         </div>
 
-        <div id="loading-spinner" class="spinner" style="none"></div>
+        <div id="loading-spinner" class="spinner" style="block"></div>
         <div id="map"></div>
 
         <script src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places&callback=initMap" defer loading="async"></script>
 
     </div>
 </body>
-</html>


### PR DESCRIPTION
**修正地圖探索搜尋功能**

1. 搜尋框自動搜索
2. 搜尋單一景點後，再按附近景點，動態拉回目前使用者位置

**路線規劃清空及 trip_id 唯一性**

1. 路線規劃功能不論是否已經加入景點，都預設定位當前使用者並清空
2. 由 trip_id 群組後，再用 date 做分別，即使日子重疊，還是單一 trip_id 重新規劃，不互相干擾

https://github.com/astrocamp/16th-TripWay/assets/162076462/01223f51-0b55-4e37-b658-dc1aa3cebce1

