### PR TITLE
Issue #142 表單「防呆」，新增後端驗證

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,7 +25,6 @@ RespondType=
 
 #網域
 HOST_NAME=  
-NOW_HOST=
 
 # Google Map
 GOOGLE_API_KEY=

--- a/members/views.py
+++ b/members/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from .forms import SignUp
 from .models import MemberSpot, Member
@@ -47,7 +48,7 @@ def register_user(request):
 
     return render(request, "registration/register.html", {"form": form})
 
-
+@login_required
 def profile(request):
     member = request.user
 

--- a/notifies/views.py
+++ b/notifies/views.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render,redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
-from django.http import JsonResponse
 from .models import Notification
 
 
@@ -17,13 +16,6 @@ def mark_as_read(request, notification_id):
         notification.is_read = True
         notification.save()
     return redirect("notifies:notification_list")
-
-
-@login_required
-def update_notification_status(request):
-    # 更新通知狀態，將未讀通知標示為已讀
-    Notification.objects.filter(user=request.user, is_read=False).update(is_read=True)
-    return JsonResponse({'status': 'success'})
 
     
 @login_required

--- a/payments/views.py
+++ b/payments/views.py
@@ -24,7 +24,7 @@ def create_order(request):
     member = request.user
     price = request.POST["price"]
 
-    valid_prices = [300, 666, 888] 
+    valid_prices = ["300", "666", "888"] 
     if price not in valid_prices:
         messages.error(request, "無效的金額！")
         return redirect("payments:upgrade")

--- a/payments/views.py
+++ b/payments/views.py
@@ -3,6 +3,7 @@ from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 from .service import PaymentService
@@ -11,7 +12,6 @@ import os
 import json
 from .models import Payment
 
-# Create your views here.
 
 @login_required
 def upgrade(request):
@@ -23,6 +23,12 @@ def upgrade(request):
 def create_order(request):
     member = request.user
     price = request.POST["price"]
+
+    valid_prices = [300, 666, 888] 
+    if price not in valid_prices:
+        messages.error(request, "無效的金額！")
+        return redirect("payments:upgrade")
+        
     order = PaymentService(member, price).call(request)
     return render(request, "payments/check.html", order)
 

--- a/src/scripts/message.js
+++ b/src/scripts/message.js
@@ -4,12 +4,12 @@ const Toast = Swal.mixin({
   toast: true,
   position: "top",
   showConfirmButton: false,
-  timer: 2000,
+  timer: 4000,
   didOpen: (toast) => {
     toast.onmouseenter = Swal.stopTimer
     toast.onmouseleave = Swal.resumeTimer
   },
-  html: '<button id="close-toast" class="swal2-close w-0 h-0" style="display: block; background-color: transparent; border: none; position: absolute; top: 0; right: 0;">&#x2715;</button>',
+  html: '<button id="close-toast" class="swal2-close w-0 h-0" style="display: block; background-color: transparent; border: none; position: absolute; top: 0; right: 0; font-size: 20px; transform: translate(-50%, -50%);">&#x2715;</button>',
   didRender: (toast) => {
     const closeButton = toast.querySelector("#close-toast")
     closeButton.addEventListener("click", () => {

--- a/src/scripts/trips/new.js
+++ b/src/scripts/trips/new.js
@@ -26,6 +26,5 @@ function imageUpload(){
 }
 
 if (upload) {
-    console.log("aaa")
     imageUpload()
 }

--- a/static/scripts/notifications.js
+++ b/static/scripts/notifications.js
@@ -1,5 +1,5 @@
-function updateNotificationStatus() {
-    fetch("{% url 'notifies:update_notification_status' %}", {
+function markNotificationsAsRead() {
+    fetch("{% url 'notifies:mark_as_read' %}", {
         method: 'POST',
         headers: {
             "X-CSRFToken": "{{ csrf_token }}",

--- a/templates/schedules/update.html
+++ b/templates/schedules/update.html
@@ -6,14 +6,14 @@
 <div class="h-screen pt-8">
     <header class="flex justify-between items-center w-3/4 mx-auto">
       <div class="flex items-center">
-        <a class="m-1 transition-colors duration-300 hover:text-sky-700" href="javascript:history.go(-1)">
+        <a class="m-1 transition-colors duration-300 hover:text-sky-700" href="{% url 'trips:schedules:index' id=schedule.trip.id %}">
           <i class="fa-solid fa-reply text-2xl"></i>
         </a>
         <h1 class="p-2 text-3xl font-bold">編輯行程資訊</h1>
       </div>
     </header>
     <section>
-      <form action="{% url 'schedules:show' schedule.id %}" method="post" class="mt-8 mx-auto w-1/2">
+      <form action="{% url 'schedules:update' schedule.id %}" method="post" class="mt-8 mx-auto w-1/2">
       {% csrf_token %}
         <div>
           <h3 class="text-2xl">{{ schedule.spot_name }}</h3>
@@ -21,7 +21,7 @@
             <div class="flex flex-col w-1/3 pr-4" >
               <div class="flex flex-col mb-6">
                 <label for="date" class="block font-bold text-lg">日期：</label>
-                <select name="date" id="date" required="required" class="select select-bordered w-full mt-2 border-gray-400 text-lg">
+                <select name="date" id="date" class="select select-bordered w-full mt-2 border-gray-400 text-lg">
                   {% for date in date_range %}
                   <option value="{{ date|date:'Y-m-d' }}" {% if date|date:'Y-m-d' == schedule.date|date:'Y-m-d' %}selected{% endif %}>{{ date|date:'Y-m-d' }}</option>
                   {% endfor %}

--- a/templates/trips/update.html
+++ b/templates/trips/update.html
@@ -20,7 +20,7 @@
         <div class="flex">
           <div class="w-1/3 py-8">
             <div>
-              <img id="image" class="w-full h-1/3 border border-gray-400" src="{% if trips.image %}{{ trips.image.url }}{% else %}{% static 'img/tripdefault.jpeg' %}{% endif %}"/>
+              <img id="image" class="w-full h-1/3 border border-gray-400" src="{% if trip.image %}{{ trip.image.url }}{% else %}{% static 'img/tripdefault.jpeg' %}{% endif %}"/>
             </div>
             <div >
               <input type="file" id="image-upload" style="display: none" name="image" accept="image/*"/>

--- a/templates/trips/update.html
+++ b/templates/trips/update.html
@@ -7,16 +7,16 @@
 <div class="h-screen pt-8">
     <header class="flex justify-between items-center w-3/4 mx-auto">
       <div class="flex items-center">
-        <a class="m-1 transition-colors duration-300 hover:text-sky-700" href="javascript:history.go(-1)">
+        <a class="m-1 transition-colors duration-300 hover:text-sky-700" href="{% url 'trips:index' %}">
           <i class="fa-solid fa-reply text-2xl"></i>
         </a>
         <h1 class="p-2 text-3xl font-bold">編輯行程</h1>
       </div>
     </header>
     <section>
-      <form action="{% url 'trips:index' %}" method="post" class="mt-8 mx-auto w-1/2", enctype="multipart/form-data">
+      <form action="{% url 'trips:update' trip.id %}" method="post" class="mt-8 mx-auto w-1/2", enctype="multipart/form-data">
         {% csrf_token %}
-        <input type="hidden" name="trip_id" value="{{ trips.id }}">
+        <input type="hidden" name="trip_id" value="{{ trip.id }}">
         <div class="flex">
           <div class="w-1/3 py-8">
             <div>
@@ -30,21 +30,21 @@
           <div class="w-2/3 px-8">
             <div class="mb-6">
               <label for="name" class="block text-lg font-bold ">行程名稱：</label>
-              <input type="text" name="name" id="name" required="required" class="input input-bordered w-full mt-2 text-lg border-gray-400" value="{{ trips.name }}"/>
+              <input type="text" name="name" id="name" required="required" class="input input-bordered w-full mt-2 text-lg border-gray-400" value="{{ trip.name }}"/>
             </div>
             <div class="mb-6">
               <label for="start_date" class="block text-lg font-bold">出發日：</label>
-              <input type="date" name="start_date" id="start_date" required min="{% now 'Y-m-d' %}" class="input input-bordered w-full mt-2 text-lg border-gray-400" value="{{ trips.start_date|date:'Y-m-d' }}"/>
+              <input type="date" name="start_date" id="start_date" required min="{% now 'Y-m-d' %}" class="input input-bordered w-full mt-2 text-lg border-gray-400" value="{{ trip.start_date|date:'Y-m-d' }}"/>
             </div>
             <div class="mb-6">
               <label for="end_date" class="block text-lg font-bold">結束日：</label>
-              <input type="date" name="end_date" id="end_date" required min="{% now 'Y-m-d' %}" class="input input-bordered w-full mt-2 text-lg border-gray-400" value="{{ trips.end_date|date:'Y-m-d' }}"/>
+              <input type="date" name="end_date" id="end_date" required min="{% now 'Y-m-d' %}" class="input input-bordered w-full mt-2 text-lg border-gray-400" value="{{ trip.end_date|date:'Y-m-d' }}"/>
               </div>
             <div class="mb-6">
               <label for="transportation" class="block text-lg font-bold ">交通方式：</label>
-              <select class="select select-bordered w-full mt-2 border-gray-400 text-lg" name="transportation" id="transportation" value="{{ trips.transportation }}">
-                <option value="走路" {% if trips.transportation == "走路" %} selected {% endif %}>走路</option>
-                <option value="汽車" {% if trips.transportation == "汽車" %} selected {% endif %}>汽車</option>
+              <select class="select select-bordered w-full mt-2 border-gray-400 text-lg" name="transportation" id="transportation" value="{{ trip.transportation }}">
+                <option value="走路" {% if trip.transportation == "走路" %} selected {% endif %}>走路</option>
+                <option value="汽車" {% if trip.transportation == "汽車" %} selected {% endif %}>汽車</option>
               </select>
             </div>
           </div>

--- a/trips/models.py
+++ b/trips/models.py
@@ -2,9 +2,6 @@ from django.db import models
 from django.utils import timezone
 from members.models import Member
 from datetime import timedelta
-from PIL import Image
-from io import BytesIO
-
 
 class Trip(models.Model):
     name = models.CharField(max_length=100)
@@ -21,14 +18,6 @@ class Trip(models.Model):
             self.start_date + timedelta(days=x) 
             for x in range((self.end_date - self.start_date).days + 1)
         ]
-    
-    def compress_image(image):
-        img = Image.open(image)
-        img.thumbnail((200, 200))
-        output = BytesIO()
-        img.save(output, format="PNG", quality=70)
-        output.seek(0)
-        return output
 
 class TripMember(models.Model):
     trip = models.ForeignKey(Trip, on_delete=models.CASCADE)

--- a/trips/models.py
+++ b/trips/models.py
@@ -4,7 +4,6 @@ from members.models import Member
 from datetime import timedelta
 from PIL import Image
 from io import BytesIO
-from django.core.files.base import ContentFile
 
 
 class Trip(models.Model):
@@ -19,24 +18,17 @@ class Trip(models.Model):
 
     def get_date_range(self):
         return [
-            self.start_date + timedelta(days=x)
+            self.start_date + timedelta(days=x) 
             for x in range((self.end_date - self.start_date).days + 1)
         ]
-
-    def save(self, *args, **kwargs):
-        if self.image:
-            img = Image.open(self.image)
-            max_size = (600, 600)
-            img.thumbnail(max_size, Image.LANCZOS)
-            thumb_io = BytesIO()
-            img_format = "PNG" if img.mode == "RGBA" else "JPEG"
-            img.save(thumb_io, format=img_format)
-            thumb_io.seek(0)
-            file_extension = "png" if img.mode == "RGBA" else "jpg"
-            new_file_name = f"{self.image.name.split('.')[0]}_thumb.{file_extension}"
-            self.image.save(new_file_name, ContentFile(thumb_io.read()), save=False)
-        super().save(*args, **kwargs)
-
+    
+    def compress_image(image):
+        img = Image.open(image)
+        img.thumbnail((200, 200))
+        output = BytesIO()
+        img.save(output, format="PNG", quality=70)
+        output.seek(0)
+        return output
 
 class TripMember(models.Model):
     trip = models.ForeignKey(Trip, on_delete=models.CASCADE)

--- a/trips/views.py
+++ b/trips/views.py
@@ -34,9 +34,9 @@ def home(request):
         share_urls = []
         for trip in trips :
             
-            edit_url = f"https://{os.getenv("NOW_HOST")}/trips/{trip["t"].id}/add-member/edit"
-            confirm_url = f"https://{os.getenv("NOW_HOST")}/trips/{trip["t"].id}/add-member/edit/confirm"
-            watch_url = f"https://{os.getenv("NOW_HOST")}/trips/{trip["t"].id}/add-member/watch"
+            edit_url = f"https://{os.getenv("HOST_NAME")}/trips/{trip["t"].id}/add-member/edit"
+            confirm_url = f"https://{os.getenv("HOST_NAME")}/trips/{trip["t"].id}/add-member/edit/confirm"
+            watch_url = f"https://{os.getenv("HOST_NAME")}/trips/{trip["t"].id}/add-member/watch"
 
             content = {
                 "id": trip["t"].id,


### PR DESCRIPTION
https://github.com/astrocamp/16th-TripWay/assets/162015439/bde0a019-08e6-42e1-bd70-8de979837e4a

- 新增提交表單時欄位內容的後端驗證
- 金流- 防止可送出非設定金額(ex: 1 塊錢)的訂單
- 返回上一頁icon之連結路徑修正
- 修改sweetalert 錯誤訊息顯示秒數
- members/views.py裡面的profile function加上@login_required裝飾器（防止使用者輸入連結就可以看到別人的profile頁面)
- 修正trips/models.py 的compressing images函數（原本的會一直重複重新生成一個縮略圖保存在系統中導致檔名過長，當行程有照片時按加一天或減一天會跳錯誤畫面）