### PR TITLE
Issue #168 修改留言排序規則，最新的留言要顯示在最前面

### DIFF
--- a/spots/views.py
+++ b/spots/views.py
@@ -124,10 +124,15 @@ class ShowView(DetailView):
 
         return redirect("spots:show", pk=spot.id)
 
-def get_context_data(self, **kwargs):
+    def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         spot = self.get_object()
         comments = Comment.objects.filter(spot=spot).order_by('-created_at')
+
+        user_comment = None
+        if self.request.user.is_authenticated:
+            user = self.request.user
+            user_comment = comments.filter(user=user).first()
 
         total_comments = comments.count()
         average_rating = (
@@ -139,12 +144,12 @@ def get_context_data(self, **kwargs):
         place_details = self.get_place_details(place_id)
 
         if self.request.user.is_authenticated:
-            user = self.request.user
-            user_comment = comments.filter(user=user).first()
             member_spot = MemberSpot.objects.filter(spot=spot, member=self.request.user).exists()
+            user_comment_exists = user_comment is not None
             context.update(
                 {
                     "member_spot": member_spot,
+                    "user_comment_exists": user_comment_exists,
                     "user_comment": user_comment, 
                 }
             )

--- a/spots/views.py
+++ b/spots/views.py
@@ -124,15 +124,10 @@ class ShowView(DetailView):
 
         return redirect("spots:show", pk=spot.id)
 
-    def get_context_data(self, **kwargs):
+def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         spot = self.get_object()
         comments = Comment.objects.filter(spot=spot).order_by('-created_at')
-
-        user_comment = None
-        if self.request.user.is_authenticated:
-            user = self.request.user
-            user_comment = comments.filter(user=user).first()
 
         total_comments = comments.count()
         average_rating = (
@@ -144,12 +139,12 @@ class ShowView(DetailView):
         place_details = self.get_place_details(place_id)
 
         if self.request.user.is_authenticated:
+            user = self.request.user
+            user_comment = comments.filter(user=user).first()
             member_spot = MemberSpot.objects.filter(spot=spot, member=self.request.user).exists()
-            user_comment_exists = user_comment is not None
             context.update(
                 {
                     "member_spot": member_spot,
-                    "user_comment_exists": user_comment_exists,
                     "user_comment": user_comment, 
                 }
             )

--- a/templates/spots/spot_detail.html
+++ b/templates/spots/spot_detail.html
@@ -86,7 +86,7 @@
     <div class="flex flex-col items-center w-full px-3 py-3 mx-3 my-3 bg-white rounded-lg shadow-lg md:w-3/4 lg:w-1/2" style="box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 10px 20px rgba(0, 0, 0, 0.1);">
         <div class="w-full">
             <div><h1 class="text-3xl font-bold text-sky-700">評論景點</h1></div>
-            {% if not user_comment_exists %}
+            {%.if not  user_comment % &}
                 <form id="ratingForm" method="post" action="{% url "spots:show" spot.pk %}">
                     {% csrf_token %}
                     <div id="rating" class="flex justify-center text-2xl rating">

--- a/templates/spots/spot_detail.html
+++ b/templates/spots/spot_detail.html
@@ -86,7 +86,7 @@
     <div class="flex flex-col items-center w-full px-3 py-3 mx-3 my-3 bg-white rounded-lg shadow-lg md:w-3/4 lg:w-1/2" style="box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 10px 20px rgba(0, 0, 0, 0.1);">
         <div class="w-full">
             <div><h1 class="text-3xl font-bold text-sky-700">評論景點</h1></div>
-            {%.if not  user_comment % &}
+            {% if not user_comment %}
                 <form id="ratingForm" method="post" action="{% url "spots:show" spot.pk %}">
                     {% csrf_token %}
                     <div id="rating" class="flex justify-center text-2xl rating">


### PR DESCRIPTION
已修正:
1.刪除commetns/index.html，不需要這個頁面
2.最新的留言會顯示在最前面
3.因為有編輯/刪除的留言，所以已登入的使用者留言會在最前面，其他人留言一樣依新舊排序

![螢幕擷取畫面 2024-06-11 171425](https://github.com/astrocamp/16th-TripWay/assets/167298255/9297b5b8-443b-4d09-bc5b-629beb6a33c5)


